### PR TITLE
Fix base64-key parameter

### DIFF
--- a/internal/generate.go
+++ b/internal/generate.go
@@ -18,7 +18,7 @@ func Generate(c *cli.Context) error {
 	appID := c.String("app-id")
 	installationID := c.String("installation-id")
 	keyPath := c.String("key")
-	keyBase64 := c.String("key-base64")
+	keyBase64 := c.String("base64-key")
 	printJWT := c.Bool("jwt")
 	jwtExpiry := c.Int("jwt-expiry")
 	hostname := strings.ToLower(c.String("hostname"))


### PR DESCRIPTION
Fixes #29 

Main interface changes:

* <a href="diffhunk://#diff-5ad28a1fc52256696a98d442f0284446c5b25e8a1d86402c247d1be14f729bb4L21-R21">`internal/generate.go`</a>: Renamed `key-base64` flag to `base64-key` in `Generate` function for better readability.