### PR TITLE
Print error to STDERR

### DIFF
--- a/main.go
+++ b/main.go
@@ -40,7 +40,7 @@ func main() {
 
 	err := app.Run(os.Args)
 	if err != nil {
-		fmt.Printf("Error: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Updates `main.go` to send the error message to STDERR. `printf` itself does not print to stderr, only `println` and `print` do.