### PR TITLE
Fix `--duration` flag being ignored

### DIFF
--- a/internal/generate.go
+++ b/internal/generate.go
@@ -20,7 +20,7 @@ func Generate(c *cli.Context) error {
 	keyPath := c.String("key")
 	keyBase64 := c.String("base64-key")
 	printJWT := c.Bool("jwt")
-	jwtExpiry := c.Int("jwt-expiry")
+	jwtExpiry := c.Int("duration")
 	hostname := strings.ToLower(c.String("hostname"))
 	tokenOnly := c.Bool("token-only")
 	silent := c.Bool("silent")

--- a/internal/generate.go
+++ b/internal/generate.go
@@ -39,7 +39,7 @@ func Generate(c *cli.Context) error {
 	}
 
 	if jwtExpiry < 1 || jwtExpiry > 10 {
-		jwtExpiry = 5
+		jwtExpiry = 10
 	}
 
 	var err error

--- a/internal/generate.go
+++ b/internal/generate.go
@@ -39,7 +39,7 @@ func Generate(c *cli.Context) error {
 	}
 
 	if jwtExpiry < 1 || jwtExpiry > 10 {
-		jwtExpiry = 10
+		jwtExpiry = 5
 	}
 
 	var err error

--- a/internal/generate_flags.go
+++ b/internal/generate_flags.go
@@ -51,10 +51,10 @@ func GenerateFlags() []cli.Flag {
 		},
 		&cli.IntFlag{
 			Name:     "duration",
-			Usage:    "The expiry time of the JWT in minutes, from 1 to 10 (default: 5). Lower values are safer against clock drift",
+			Usage:    "The expiry time of the JWT in minutes up to a maximum value of 10, useful when using the --jwt flag",
 			Required: false,
 			Aliases:  []string{"d"},
-			Value:    5,
+			Value:    1,
 		},
 		&cli.BoolFlag{
 			Name:    "silent",

--- a/internal/generate_flags.go
+++ b/internal/generate_flags.go
@@ -51,10 +51,10 @@ func GenerateFlags() []cli.Flag {
 		},
 		&cli.IntFlag{
 			Name:     "duration",
-			Usage:    "The expiry time of the JWT in minutes up to a maximum value of 10, useful when using the --jwt flag",
+			Usage:    "The expiry time of the JWT in minutes, from 1 to 10 (default: 5). Lower values are safer against clock drift",
 			Required: false,
 			Aliases:  []string{"d"},
-			Value:    1,
+			Value:    5,
 		},
 		&cli.BoolFlag{
 			Name:    "silent",


### PR DESCRIPTION
- Reduce default JWT expiry from 10 to 5 minutes, providing a buffer against clock drift that causes GitHub to reject the token with "exp claim is too far in the future"
- Fix `--duration` / `-d` flag being silently ignored due to a name mismatch (`c.Int("jwt-expiry")` vs flag registered as `"duration"`)